### PR TITLE
chore(flake/nixpkgs): `1e5b653d` -> `698214a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`76996edb`](https://github.com/NixOS/nixpkgs/commit/76996edbe9462476e1deabcbf8e0deda332e20b6) | `` mtools: enable parallel building ``                                               |
| [`fa13f729`](https://github.com/NixOS/nixpkgs/commit/fa13f7297f20f8d9a51f3d685420f4993327916d) | `` mtools: 4.0.47 -> 4.0.48 ``                                                       |
| [`372f7b72`](https://github.com/NixOS/nixpkgs/commit/372f7b72f66cad4035b4609c88a6f32508fe1dbd) | `` composer-require-checker: add `versionCheckHook` ``                               |
| [`21184f50`](https://github.com/NixOS/nixpkgs/commit/21184f50bd10a190ef4e85d2a24a8add1a6499d9) | `` phpactor: add `versionCheckHook` ``                                               |
| [`35f5375e`](https://github.com/NixOS/nixpkgs/commit/35f5375e16589ae4dce6b1179fad622a73aecd21) | `` presenterm: 0.11.0 -> 0.12.0 ``                                                   |
| [`090bfb5f`](https://github.com/NixOS/nixpkgs/commit/090bfb5fcff97522d4434328ef5bb99ea5f1a1a5) | `` ripgrep-all: use fetchCargoVendor ``                                              |
| [`7076bd45`](https://github.com/NixOS/nixpkgs/commit/7076bd458c6f4dfb05e39d052e1b37cad1638ace) | `` rustplayer: use fetchCargoVendor ``                                               |
| [`060b9031`](https://github.com/NixOS/nixpkgs/commit/060b90315044455b053b3334a91cdff0c66503f8) | `` rtz: use fetchCargoVendor ``                                                      |
| [`7ca409f9`](https://github.com/NixOS/nixpkgs/commit/7ca409f9515bc97ea2d0adcca2f66cd7816f0bd9) | `` rmenu: use fetchCargoVendor ``                                                    |
| [`4608792a`](https://github.com/NixOS/nixpkgs/commit/4608792af542d243b671061ba712c9591663f069) | `` roon-tui: use fetchCargoVendor ``                                                 |
| [`48280859`](https://github.com/NixOS/nixpkgs/commit/48280859f2c8643ed6d177bbd7bdd273179c7ef3) | `` oprofile: cleanup ``                                                              |
| [`9b3c45be`](https://github.com/NixOS/nixpkgs/commit/9b3c45be5ed532cac9a42704e5a16a6ce35856a8) | `` oprofile: fix build with gcc14 ``                                                 |
| [`0a23e921`](https://github.com/NixOS/nixpkgs/commit/0a23e921032b47cf205a0842472c9c780b9d11dd) | `` syncstorage-rs: use fetchCargoVendor ``                                           |
| [`d56b5a4b`](https://github.com/NixOS/nixpkgs/commit/d56b5a4b05e2c9a712abc206e517b0f424606fd3) | `` rust-synapse-compress-state: use fetchCargoVendor ``                              |
| [`a0815750`](https://github.com/NixOS/nixpkgs/commit/a0815750f16b9d1b71ee70ffc12e2134e21df357) | `` pomsky: use fetchCargoVendor ``                                                   |
| [`1c6716d1`](https://github.com/NixOS/nixpkgs/commit/1c6716d1eea4f9b1e68248f5cc158382af944052) | `` polarity: use fetchCargoVendor ``                                                 |
| [`35a3805e`](https://github.com/NixOS/nixpkgs/commit/35a3805e92d6bd1bf4cd2d848651bcbe250e45df) | `` you-have-mail-cli: use fetchCargoVendor ``                                        |
| [`c4d57415`](https://github.com/NixOS/nixpkgs/commit/c4d57415236c4a10d2e6c672973c9b3d55672d4b) | `` you-have-mail-cli: use cargoDepsCopy shell variable ``                            |
| [`ad32e759`](https://github.com/NixOS/nixpkgs/commit/ad32e7593119b6cf6788d5606fadf0ad6fce4f0a) | `` oxide-rs: use fetchCargoVendor ``                                                 |
| [`a115fc12`](https://github.com/NixOS/nixpkgs/commit/a115fc12505372ae638ce76939fd38e47c9227a6) | `` tunnelto: use fetchCargoVendor ``                                                 |
| [`c3c8a2a1`](https://github.com/NixOS/nixpkgs/commit/c3c8a2a16acc2a338787f534e5a083db675d4420) | `` cotton: use fetchCargoVendor ``                                                   |
| [`4a5e09f9`](https://github.com/NixOS/nixpkgs/commit/4a5e09f9a4d0972dcba8555cd21cc7aab748f10d) | `` ciel: use fetchCargoVendor ``                                                     |
| [`b9bf8b7e`](https://github.com/NixOS/nixpkgs/commit/b9bf8b7eee93ff1d78143337c5e86f3e925c0e65) | `` emacsPackages.tsc: use fetchCargoVendor ``                                        |
| [`0c522431`](https://github.com/NixOS/nixpkgs/commit/0c522431926ba5c7801fe547be5382b3f091fa31) | `` pyradio: 0.9.3.11.5 -> 0.9.3.11.8 ``                                              |
| [`c432bc87`](https://github.com/NixOS/nixpkgs/commit/c432bc87013065b1b48d2bd8252d957c97101957) | `` telegraf: 1.34.0 -> 1.34.1 ``                                                     |
| [`c137d724`](https://github.com/NixOS/nixpkgs/commit/c137d724e040ef671c5a3fbf08da82c0c239ce07) | `` bpfilter: 0.2.1 -> 0.3.0 ``                                                       |
| [`126db443`](https://github.com/NixOS/nixpkgs/commit/126db443ed3f0e585ee83c9ebe6547ec09168efa) | `` ocamlPackages.monolith: init at 20250314 ``                                       |
| [`55944768`](https://github.com/NixOS/nixpkgs/commit/55944768eafd7c5311bbb1cdc91157cec24b387a) | `` komodo: 1.17.0-dev-7 -> 1.17.0 ``                                                 |
| [`15c8a58d`](https://github.com/NixOS/nixpkgs/commit/15c8a58d70ac9b4190d939792ae28c9f258b7cc0) | `` depotdownloader: Migrate to by-name ``                                            |
| [`f0bd3092`](https://github.com/NixOS/nixpkgs/commit/f0bd30927b4dcfb6ce0b94a4b2306c4e5ea145f2) | `` archi: Migrate to by-name ``                                                      |
| [`7e19a7f4`](https://github.com/NixOS/nixpkgs/commit/7e19a7f48ccc93b50cc1798630d9e8ebaf1775cc) | `` shopware-cli: 0.5.9 -> 0.5.12 ``                                                  |
| [`ce92ea38`](https://github.com/NixOS/nixpkgs/commit/ce92ea38958b023ba6a7e833dbacd660fc8bc600) | `` maintainers: isabelroses add matrix ``                                            |
| [`764fe4dd`](https://github.com/NixOS/nixpkgs/commit/764fe4dd93d276841b7a7368f3e23da756be45b8) | `` wallust: 3.2.0 -> 3.3.0 ``                                                        |
| [`6cb0be2c`](https://github.com/NixOS/nixpkgs/commit/6cb0be2c51c02bcd404d6f829b6e7b75f45bf009) | `` python312Packages.awkward: 2.8.0 -> 2.8.1 (#392908) ``                            |
| [`366c163f`](https://github.com/NixOS/nixpkgs/commit/366c163f6b79532384af6a0a49d98dd19835b72c) | `` nezha-agent: 1.9.5 -> 1.9.7 ``                                                    |
| [`0d25c102`](https://github.com/NixOS/nixpkgs/commit/0d25c102b20967a4137c13b084f0b5af40c9bc9a) | `` python313Packages.click-option-group: 0.5.6 -> 0.5.7 ``                           |
| [`eefd9323`](https://github.com/NixOS/nixpkgs/commit/eefd9323ae72b2984726636cf29eadbed9b29ca0) | `` Revert "24.11 beta release" ``                                                    |
| [`a1f1ad4c`](https://github.com/NixOS/nixpkgs/commit/a1f1ad4c4f761a13f900175157b619d7da0bd250) | `` python312Packages.colbert-ai: mark as broken on darwin ``                         |
| [`833db48a`](https://github.com/NixOS/nixpkgs/commit/833db48ad16147e5a855133df643005cef0e4f9e) | `` hplip: fix building with python 3.12 ``                                           |
| [`f96eda85`](https://github.com/NixOS/nixpkgs/commit/f96eda85f3a6bca005707ab40bc71364e398acc0) | `` python312Packages.colbert-ai: fix import ``                                       |
| [`15f5f3a9`](https://github.com/NixOS/nixpkgs/commit/15f5f3a99ddac36c60f829eda6e84652943117a3) | `` python312Packages.async-stagger: 0.4.0.post1 -> 0.4.1 (#392324) ``                |
| [`e05c24f1`](https://github.com/NixOS/nixpkgs/commit/e05c24f19f11bb03d049949b10cea3120fc22ef9) | `` python312Packages.docling: skip failing tests on darwin ``                        |
| [`b109774a`](https://github.com/NixOS/nixpkgs/commit/b109774a10da1aa5738db703a87f17edee2d6936) | `` python312Packages.docling-ibm-models: skip failing tests on darwin ``             |
| [`ffad8aa1`](https://github.com/NixOS/nixpkgs/commit/ffad8aa18cf1970e11df1aefb8348c3aa8fe59e8) | `` forgejo-runner: 6.3.0 -> 6.3.1 ``                                                 |
| [`3f0251f7`](https://github.com/NixOS/nixpkgs/commit/3f0251f7293b654e667e91aa90802d845c43c1f2) | `` home-assistant-custom-components.xiaomi_miot: 1.0.13 -> 1.0.15 (#392884) ``       |
| [`3a122b21`](https://github.com/NixOS/nixpkgs/commit/3a122b21d8c61f44dcbddce5eaf4ffc63e348ba0) | `` python312Packages.docling-ibm-models: relax jsonlines dependency ``               |
| [`f8a5b639`](https://github.com/NixOS/nixpkgs/commit/f8a5b6393a6cb0673fe4a4cfeb163a5128f7ea6d) | `` phpPackages.psysh: fix `versionCheckHook` syntax ``                               |
| [`7ec7f1da`](https://github.com/NixOS/nixpkgs/commit/7ec7f1dad7f1f25d50c792f0e38a58fb1bfe938f) | `` phpPackages.php-cs-fixer: 3.70.1 -> 3.73.1 ``                                     |
| [`0ab9f25a`](https://github.com/NixOS/nixpkgs/commit/0ab9f25ada2d9b196ea1c2c24f518a9f0b3a9281) | `` python312Packages.python-linkplay: 0.1.3 -> 0.2.1 ``                              |
| [`caa152cf`](https://github.com/NixOS/nixpkgs/commit/caa152cfd6b7b622d581b1dbb93ead63124092be) | `` wait4x: 3.1.0 -> 3.2.0 ``                                                         |
| [`98d6d2a7`](https://github.com/NixOS/nixpkgs/commit/98d6d2a7cad856d212227a812ed0697598129f72) | `` python3Packages.asyncpg: enable tests again ``                                    |
| [`6da63280`](https://github.com/NixOS/nixpkgs/commit/6da63280dff06cd4928614a210faeb1daaaa8aeb) | `` python3Packages.asyncpg: disable a test broken by python ``                       |
| [`dec96138`](https://github.com/NixOS/nixpkgs/commit/dec961382c44dce1aa70d15431ce468cf681fb76) | `` postgresqlTestHook: mark as broken for darwin ``                                  |
| [`b59bc4ff`](https://github.com/NixOS/nixpkgs/commit/b59bc4ff1d89f6969a0b32bc32f6c154093bbaf4) | `` charm-freeze: 0.1.6 -> 0.2.0 ``                                                   |
| [`d5e65218`](https://github.com/NixOS/nixpkgs/commit/d5e65218dec187d733e627fdaaed7a1106f48442) | `` dalfox: 2.9.3 -> 2.10.0 ``                                                        |
| [`9b37c184`](https://github.com/NixOS/nixpkgs/commit/9b37c18493d00b561cc339a215911ccb4345a19c) | `` xrizer: link libGLX ``                                                            |
| [`6d5b9ed3`](https://github.com/NixOS/nixpkgs/commit/6d5b9ed3f2e77767e3f5d934c8ef44b7cf02b116) | `` confluent-cli: change license to unfreeRedistributable ``                         |
| [`5c72fd68`](https://github.com/NixOS/nixpkgs/commit/5c72fd684249c99b173fbc33ef82c460f414f60b) | `` nixos/bat: fix settings type handling ``                                          |
| [`2a94cf34`](https://github.com/NixOS/nixpkgs/commit/2a94cf34a1dac4aaa1f38d6ec6577b5457bdebb1) | `` arkade: 0.11.36 -> 0.11.37 ``                                                     |
| [`570b4027`](https://github.com/NixOS/nixpkgs/commit/570b40278bcdaaa2e86cedcf5809f9bb020c00ff) | `` gay: 1.2.9 -> 1.3.4 ``                                                            |
| [`1f7c0731`](https://github.com/NixOS/nixpkgs/commit/1f7c07318fc0c575cc80bd3afbf67bfc547c4794) | `` py-spy: set platforms, mark as broken for aarch64 ``                              |
| [`45adca4d`](https://github.com/NixOS/nixpkgs/commit/45adca4d67548c38ddf5f512712bcb495ee8c930) | `` nordzy-cursor-theme: 2.3.0 -> 2.4.0 ``                                            |
| [`a49fec6d`](https://github.com/NixOS/nixpkgs/commit/a49fec6d0fc311068befc4614550087cdc1ec03e) | `` spacetimedb: 1.0.0 -> 1.0.1 ``                                                    |
| [`9bd49a13`](https://github.com/NixOS/nixpkgs/commit/9bd49a13c2a33802743aa229a0fab8c4ea66d204) | `` python312Packages.pymilvus: 2.5.5 -> 2.5.6 ``                                     |
| [`b763e93a`](https://github.com/NixOS/nixpkgs/commit/b763e93a9510c2d511e0f1c2550907a3fa985607) | `` vscode-extensions.ms-python.python: 2025.3.2025031001 -> 2024.15.2024091301 ``    |
| [`682ff8fd`](https://github.com/NixOS/nixpkgs/commit/682ff8fda76c231d8fce5fc1386a5452d0a121c4) | `` tuifeed: 0.3.2 -> 0.4.1 ``                                                        |
| [`03f06cc8`](https://github.com/NixOS/nixpkgs/commit/03f06cc81d58e4d6324d08c92cfff81073b9c8db) | `` phpunit: add `versionCheckHook` ``                                                |
| [`720d9347`](https://github.com/NixOS/nixpkgs/commit/720d9347d8c3f9c978a44d257d6bcf9d66c02d69) | `` phel: fix `versionCheckHook` syntax ``                                            |
| [`b10c0679`](https://github.com/NixOS/nixpkgs/commit/b10c0679ef60993464d53ea81bdc155c09ee0859) | `` phpPackages.box: fix `versionCheckHook` syntax ``                                 |
| [`cfe3fd43`](https://github.com/NixOS/nixpkgs/commit/cfe3fd43e0954e8b294ac682cb80daf71eec5f1e) | `` phpPackages.grumphp: add `versionCheckHook` ``                                    |
| [`5f238719`](https://github.com/NixOS/nixpkgs/commit/5f2387195a080c9e61be5ce1a43fbdc9fc7e4703) | `` phpPackages.phpstan: add `versionCheckHook` ``                                    |
| [`0f1b0ebc`](https://github.com/NixOS/nixpkgs/commit/0f1b0ebc775d4144f6c5c7e6b3903b31dfb8cb2c) | `` phpPackages.psalm: fix `versionCheckHook` syntax ``                               |
| [`711d454a`](https://github.com/NixOS/nixpkgs/commit/711d454a1e072478111100281e2599ce2bdbe11a) | `` phpPackages.composer: add `versionCheckHook` ``                                   |
| [`d19e76a7`](https://github.com/NixOS/nixpkgs/commit/d19e76a70fc33f3586e99a17be7a722ce5e24b19) | `` below: replace vendored patch with an upstream commit ``                          |
| [`2987a2c4`](https://github.com/NixOS/nixpkgs/commit/2987a2c4c39c742228108ef6f627dcdb74a1e45b) | `` lcevcdec: fix pkg-config version data ``                                          |
| [`9c5fd48c`](https://github.com/NixOS/nixpkgs/commit/9c5fd48c7c4aaf5893fd9bbbcfb197acc5a71756) | `` typst: fix `versionCheckHook` syntax ``                                           |
| [`c63de0f8`](https://github.com/NixOS/nixpkgs/commit/c63de0f864537437b9ae7b03188a98dc8f682cd7) | `` google-chrome: 134.0.6998.88 -> 134.0.6998.165 ``                                 |
| [`b66bbd14`](https://github.com/NixOS/nixpkgs/commit/b66bbd147e0c6193af3cdd715ce8c3cfb02fc963) | `` mozillavpn: 2.25.0 -> 2.26.0 ``                                                   |
| [`6753845f`](https://github.com/NixOS/nixpkgs/commit/6753845f71dbeead3ac30a05418960d801f2d978) | `` cnquery: 11.45.1 -> 11.46.2 ``                                                    |
| [`e15e4b63`](https://github.com/NixOS/nixpkgs/commit/e15e4b63737cdc174e5c9a6a6394514e7d88fce1) | `` ungoogled-chromium: 134.0.6998.117-1 -> 134.0.6998.165-1 ``                       |
| [`ebc3045b`](https://github.com/NixOS/nixpkgs/commit/ebc3045b5e7e6da051db75e0bcd3c7306ddc4fcd) | `` prometheus-knot-exporter: 3.4.4 -> 3.4.5 ``                                       |
| [`aac79645`](https://github.com/NixOS/nixpkgs/commit/aac796450c26a1b0ddaa26b4725e0c030ed660c0) | `` signalbackup-tools: 20250319 -> 20250322 ``                                       |
| [`45c2586a`](https://github.com/NixOS/nixpkgs/commit/45c2586ab181bd0133b7cff9d5abcd7f8eb27ede) | `` uiua-unstable: 0.15.0-dev.2 -> 0.15.0-rc.1 ``                                     |
| [`e6b42606`](https://github.com/NixOS/nixpkgs/commit/e6b42606eae5a07f646e95afe5e3d85bd8ef7374) | `` python312Packages.weaviate-client: 4.11.1 -> 4.11.2 ``                            |
| [`fdc66ee0`](https://github.com/NixOS/nixpkgs/commit/fdc66ee0183b6ef7a36e39189e030881c27da50c) | `` hddfancontrol: 2.0.1->2.0.2 (#392550) ``                                          |
| [`2733cb9f`](https://github.com/NixOS/nixpkgs/commit/2733cb9f6c82eab340029f7851e82ec782e9de51) | `` cjdns: use fetchCargoVendor ``                                                    |
| [`d41dd5b2`](https://github.com/NixOS/nixpkgs/commit/d41dd5b29fe9477cd25bf9cbfda5376d9e9fd45b) | `` woomer: use fetchCargoVendor ``                                                   |
| [`0ab09920`](https://github.com/NixOS/nixpkgs/commit/0ab09920fa857b4b5a1a029d81189b6b671c7027) | `` phpunit: 12.0.7 -> 12.0.10 ``                                                     |
| [`3a35a84d`](https://github.com/NixOS/nixpkgs/commit/3a35a84d9d4bb82613ca128a4a3d2aabdc92b0dc) | `` python313Packages.python-telegram-bot: 21.11.1 -> 22.0 ``                         |
| [`3b054f12`](https://github.com/NixOS/nixpkgs/commit/3b054f124ffe84763cef04c8cab7c6eaf2c82a0b) | `` python313Packages.pydeconz: 119 -> 120 ``                                         |
| [`c7ffb4ba`](https://github.com/NixOS/nixpkgs/commit/c7ffb4ba0621bdd6b3d88a3c0b6abf5c9ce3159c) | `` jazz2: cleanup ``                                                                 |
| [`e3576b44`](https://github.com/NixOS/nixpkgs/commit/e3576b4482f7463820dfe91c6cd428f690f945e3) | `` python313Packages.androidtvremote2: 0.2.0 -> 0.2.1 ``                             |
| [`787a995b`](https://github.com/NixOS/nixpkgs/commit/787a995b1733bb693445f589613a9066c848b9e4) | `` agrep: unbreak ``                                                                 |
| [`6f134087`](https://github.com/NixOS/nixpkgs/commit/6f1340879c5156aaa3c9bf11e1f28f53eaaf1f52) | `` pict-rs_0_3: remove leftover files ``                                             |
| [`022304af`](https://github.com/NixOS/nixpkgs/commit/022304afc1305a265993e1f12ca45f94f37e1d25) | `` symbolicator: use fetchCargoVendor ``                                             |
| [`9c8e2844`](https://github.com/NixOS/nixpkgs/commit/9c8e284465fb7373437ef06f2b499b72c98a0c80) | `` svix-server: use fetchCargoVendor ``                                              |
| [`1870772d`](https://github.com/NixOS/nixpkgs/commit/1870772d44afd94548ad1308d692d7d4ef3c762c) | `` surfer: use fetchCargoVendor ``                                                   |
| [`8c5b761f`](https://github.com/NixOS/nixpkgs/commit/8c5b761f57af825a62de2d74c070f62367a071d0) | `` surface-control: use fetchCargoVendor ``                                          |
| [`cf3195ca`](https://github.com/NixOS/nixpkgs/commit/cf3195ca73ee0a7a395ac271a20aca13d5d627d9) | `` substudy: use fetchCargoVendor ``                                                 |
| [`b053039c`](https://github.com/NixOS/nixpkgs/commit/b053039ce88e90d0f42ca3900bef61f9a8a38d8e) | `` gpxsee: 13.37 -> 13.38 ``                                                         |
| [`112c8041`](https://github.com/NixOS/nixpkgs/commit/112c80411c78dfc470d9d99a3c6eff6b60257a3e) | `` wl-gammarelay-rs: use fetchCargoVendor ``                                         |
| [`6763ae27`](https://github.com/NixOS/nixpkgs/commit/6763ae27e2a8057e205db7da70338dccb376d418) | `` mpvScripts.mpv-playlistmanager: 0-unstable-2025-02-23 -> 0-unstable-2025-03-16 `` |
| [`31edf3dc`](https://github.com/NixOS/nixpkgs/commit/31edf3dc79556103312079c64c6510cb2c5521e6) | `` python312Packages.chromadb: unbreak build by disabling a test ``                  |
| [`4f6a6b26`](https://github.com/NixOS/nixpkgs/commit/4f6a6b26e8917167e04020a22821194d62d43c5b) | `` pw-viz: use fetchCargoVendor ``                                                   |
| [`f5ee76b1`](https://github.com/NixOS/nixpkgs/commit/f5ee76b15d46a767af5795c04d0b0d6e7f449754) | `` vimPlugins.nvim-rg: init at 2025-02-09 ``                                         |
| [`21e5db95`](https://github.com/NixOS/nixpkgs/commit/21e5db955858e4b58ef85e1cdfe33b2522ee1528) | `` pixelfed: fix passthru test inheritance ``                                        |
| [`de22d6f4`](https://github.com/NixOS/nixpkgs/commit/de22d6f4945d7ac0a7726e4831c85057d8852499) | `` nexusmods-app: 0.8.2 -> 0.8.3 ``                                                  |