### PR TITLE
chore(flake/nixpkgs): `91bf6dff` -> `f02fddb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746064326,
-        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`22809c01`](https://github.com/NixOS/nixpkgs/commit/22809c01e4928fa58d986701ffc6a631edf58a4b) | `` banana-accounting: 10.0.12 -> 10.1.24 ``                                   |
| [`9c3faa2d`](https://github.com/NixOS/nixpkgs/commit/9c3faa2d1b2a4d26bcfc1a19429331867a09cfbc) | `` hheretic: add missing libGL and libGLU depends ``                          |
| [`9750c009`](https://github.com/NixOS/nixpkgs/commit/9750c0094b59ff8d4bcb4efeb814ef7ec3d96c16) | `` python312Packages.orbax-checkpoint: 0.11.12 -> 0.11.13 ``                  |
| [`e1d9f8da`](https://github.com/NixOS/nixpkgs/commit/e1d9f8daed0f0c13b15128ba118f0c3021ab761b) | `` wapiti: 3.2.2 -> 3.2.4 ``                                                  |
| [`5c22abdc`](https://github.com/NixOS/nixpkgs/commit/5c22abdcc1e4c5393e2a02b1b0aadbd732939630) | `` smtp4dev: 3.6.1 -> 3.8.6 ``                                                |
| [`a3520e95`](https://github.com/NixOS/nixpkgs/commit/a3520e957782c879440560180cd25c967d54364f) | `` Revert "ci/compare: Bring back nix stats comparison" ``                    |
| [`96b4934c`](https://github.com/NixOS/nixpkgs/commit/96b4934ce68c75ad41e7af2c80f04ed900d3320b) | `` python312Packages.array-record: 0.7.1 -> 0.7.2 ``                          |
| [`78e89923`](https://github.com/NixOS/nixpkgs/commit/78e899234534c28270d00a7f90a7192c73228bdd) | `` ci/compare: nix stats comparison ``                                        |
| [`16cc7a3a`](https://github.com/NixOS/nixpkgs/commit/16cc7a3a86d15151b558b83a479669831b3fec45) | `` python312Packages.arsenic-swagger: init at 0.1.9 ``                        |
| [`41644fbc`](https://github.com/NixOS/nixpkgs/commit/41644fbcd5eb8f631854047ab3ad640275ecf002) | `` python312Packages.wapiti-arsenit: init at 28.2 ``                          |
| [`ef5267ea`](https://github.com/NixOS/nixpkgs/commit/ef5267ea6199de1aeaec54f2a7c55a1087456a11) | `` arma3-unix-launcher: 413-unstable-2025-02-10 -> 420 ``                     |
| [`a7d69371`](https://github.com/NixOS/nixpkgs/commit/a7d6937134210168dffe098982bcef27e7d75c5c) | `` lincity_ng: add missing deps ``                                            |
| [`6bd931ea`](https://github.com/NixOS/nixpkgs/commit/6bd931ea98cf497afea710af8027c59c4751daa6) | `` atmos: 1.95.0 -> 1.171.0 ``                                                |
| [`8f90d078`](https://github.com/NixOS/nixpkgs/commit/8f90d078504435b5369d9dca3bf76e08866ee0a2) | `` kstars: fix eval ``                                                        |
| [`5b25f97f`](https://github.com/NixOS/nixpkgs/commit/5b25f97f2e94c0b107acbfb87b1ca69f0d26aff4) | `` pipewire: Add bluezSupport parameter ``                                    |
| [`2c14a3e7`](https://github.com/NixOS/nixpkgs/commit/2c14a3e73eb591b48bfed632bc760b15153496dd) | `` mongodb-compass: add darwin support and split package file ``              |
| [`dad52880`](https://github.com/NixOS/nixpkgs/commit/dad528800a7a431934c80dc972ba94664eaeb603) | `` nixos/restic-rest-server: fixed typos. ``                                  |
| [`f31e3539`](https://github.com/NixOS/nixpkgs/commit/f31e3539c6507de250918a62748b4b9c6ab58fa6) | `` mdbook-katex: 0.9.3 -> 0.9.4 ``                                            |
| [`2bc87b29`](https://github.com/NixOS/nixpkgs/commit/2bc87b29cc0fd8bad41e3de7bd0c77266abd1bfc) | `` surrealdb: 2.2.2 -> 2.3.0 ``                                               |
| [`e1b2c783`](https://github.com/NixOS/nixpkgs/commit/e1b2c7837871f7599128647c5740150a95d00985) | `` fleetctl: keep in sync with fleet ``                                       |
| [`fa69ce05`](https://github.com/NixOS/nixpkgs/commit/fa69ce05d6461998bf9b8ea6095e3abe9140403a) | `` ci/eval: output per chunk stats ``                                         |
| [`ca52c152`](https://github.com/NixOS/nixpkgs/commit/ca52c152838b76bd3883eba4789d4ee98bf41844) | `` gildas: fix build on aarch64-linux and x86_64-linux ``                     |
| [`490852cc`](https://github.com/NixOS/nixpkgs/commit/490852ccfd2c214acc03ef5968be4ba84dca88d8) | `` zigbee2mqtt_2: 2.2.1 -> 2.3.0 ``                                           |
| [`42152562`](https://github.com/NixOS/nixpkgs/commit/42152562d6b18674eb0110225480736ec19a6a1a) | `` python312Packages.hcloud: 2.4.0 -> 2.5.1 ``                                |
| [`8b057ae9`](https://github.com/NixOS/nixpkgs/commit/8b057ae9d77e861413bea6e20f3209044226847e) | `` libtcod: fix build ``                                                      |
| [`b141309d`](https://github.com/NixOS/nixpkgs/commit/b141309d3f92b9dad56b06066c90be8ce4850d76) | `` ruff: 0.11.7 -> 0.11.8 ``                                                  |
| [`5948c88c`](https://github.com/NixOS/nixpkgs/commit/5948c88c4ef8fc4a0e4e4689d8c06f4065061821) | `` boa: 0.17.3 -> 0.20 ``                                                     |
| [`17e90629`](https://github.com/NixOS/nixpkgs/commit/17e90629c2b6cadaea9d7fcc7d6a8d7ec6d48748) | `` tmuxPlugins.fingers: 2.2.2 -> 2.4.0 ``                                     |
| [`48ab2b2f`](https://github.com/NixOS/nixpkgs/commit/48ab2b2fa6e729ee51865de1bf5b8010c5dd2870) | `` python312Packages.msprime: 1.3.3 -> 1.3.4 ``                               |
| [`a2e18fa8`](https://github.com/NixOS/nixpkgs/commit/a2e18fa892cf1bdc30ddae2575010a69ead0b3aa) | `` ansel: fix build ``                                                        |
| [`140b3a3a`](https://github.com/NixOS/nixpkgs/commit/140b3a3a59b33d196164666f121071192cac34aa) | `` python312Packages.snakemake: 9.3.0 -> 9.3.3 ``                             |
| [`6576844f`](https://github.com/NixOS/nixpkgs/commit/6576844fb3f09a3ab102b92e831bf8ade733a58c) | `` backward-cpp: use cmake as a build system ``                               |
| [`bec87814`](https://github.com/NixOS/nixpkgs/commit/bec8781463ebe9f5da69c3e33dce0450a41538fa) | `` python312Packages.pathlib-abc: 0.4.1 -> 0.4.3 ``                           |
| [`9eaf61e2`](https://github.com/NixOS/nixpkgs/commit/9eaf61e2ff601d2849c42ec394900d1950bb63b4) | `` gildas: add an update script ``                                            |
| [`1963e93d`](https://github.com/NixOS/nixpkgs/commit/1963e93d71ab8a5c51901ffd53e68949dd0afb6b) | `` hyprutils: 0.6.0 -> 0.7.0 ``                                               |
| [`031084a9`](https://github.com/NixOS/nixpkgs/commit/031084a9903cd059a3e8998f3ac2b8e54b89d66b) | `` virtualboxKvm: use the patch from the 7.1.6 version ``                     |
| [`441ea5a9`](https://github.com/NixOS/nixpkgs/commit/441ea5a9f4273f622677bb557c13fad3706cdb37) | `` libation: 11.5.5 -> 12.3.1 ``                                              |
| [`5e274a3b`](https://github.com/NixOS/nixpkgs/commit/5e274a3b591dac7a237a3c4922bbc026bffd5b61) | `` hedgedoc-cli: 1.0 -> 1.0-unstable-2025-05-01 ``                            |
| [`5fa75784`](https://github.com/NixOS/nixpkgs/commit/5fa75784e8628af328e298ccbd5fa9b31454b408) | `` python312Packages.pycrdt: 0.12.14 -> 0.12.15 ``                            |
| [`4d3c001e`](https://github.com/NixOS/nixpkgs/commit/4d3c001e7f990c77d518ccf363f430247e4d39a7) | `` fleet: 4.67.1 -> 4.67.2 ``                                                 |
| [`0ac981e2`](https://github.com/NixOS/nixpkgs/commit/0ac981e2d66cef74d2eb5420d6323fdf4e085976) | `` gh: 2.71.2 -> 2.72.0 ``                                                    |
| [`bdf59686`](https://github.com/NixOS/nixpkgs/commit/bdf596866e71b03c09450414ec5874c3554fc768) | `` dotnetPackages.{NewtonsoftJson,Paket}: remove env-vars from output ``      |
| [`c68da34e`](https://github.com/NixOS/nixpkgs/commit/c68da34e753630939d51d1c029a18411a0f8b845) | `` xmage: remove env-vars from output ``                                      |
| [`8062d9b7`](https://github.com/NixOS/nixpkgs/commit/8062d9b70c386366484c8c2cffd0e731f35964e6) | `` unihan-database: remove env-vars from output ``                            |
| [`9dbb7d34`](https://github.com/NixOS/nixpkgs/commit/9dbb7d345925fbd91a73fe02a3867ee02591019b) | `` powershell: remove env-vars from output ``                                 |
| [`8bf09825`](https://github.com/NixOS/nixpkgs/commit/8bf098259ead32c8d3581af2e8cd991058f48f0d) | `` ombi: remove env-vars from output ``                                       |
| [`10a6fe94`](https://github.com/NixOS/nixpkgs/commit/10a6fe9487c55bcee896445991406c516f1c1e31) | `` geoserver: remove env-vars from output ``                                  |
| [`76c48d81`](https://github.com/NixOS/nixpkgs/commit/76c48d819fdfd18c6705403b96c23fcd3b66a68d) | `` davmail: remove env-vars from output ``                                    |
| [`6ce84285`](https://github.com/NixOS/nixpkgs/commit/6ce8428510ccba5b2feca3b5451ec6787ed42681) | `` python312Packages.lightning: drop tensorboardx dep as it's now optional `` |
| [`15dab23a`](https://github.com/NixOS/nixpkgs/commit/15dab23a42759a33cb4288fd17195d5fc09aeab2) | `` mixxx: 2.5.0 -> 2.5.1 ``                                                   |
| [`d4ea574d`](https://github.com/NixOS/nixpkgs/commit/d4ea574d8e29e1d88c0fdb85b77ad5147373fe9c) | `` python312Packages.ufomerge: 1.8.3 -> 1.9.1 ``                              |
| [`3e5e7715`](https://github.com/NixOS/nixpkgs/commit/3e5e7715e7a381fa0c8a75767424b313b58ee968) | `` mbuffer: 20241007 -> 20250429 ``                                           |
| [`71e129fe`](https://github.com/NixOS/nixpkgs/commit/71e129fe41056dd13c4b91b55f5792d30fbc5244) | `` python312Packages.apkinspector: 1.3.3 -> 1.3.4 ``                          |
| [`90da7eb1`](https://github.com/NixOS/nixpkgs/commit/90da7eb1bc0c3842ebee1e2ce9f379431bc3f898) | `` pkl: init at 0.28.2 ``                                                     |
| [`07cbd331`](https://github.com/NixOS/nixpkgs/commit/07cbd331454c8d4b3361f0212444f2babb62eb06) | `` mpvScripts.modernz: 0.2.7 -> 0.2.8 ``                                      |
| [`c76d7fc1`](https://github.com/NixOS/nixpkgs/commit/c76d7fc1d4fee19617014523091e49fa762c67ec) | `` xrootd: 5.8.0 -> 5.8.1 ``                                                  |
| [`582c55b7`](https://github.com/NixOS/nixpkgs/commit/582c55b7c414d199687160bf61d49a31e57eb67a) | `` maintainers: add nagymathev ``                                             |
| [`ee4f1a85`](https://github.com/NixOS/nixpkgs/commit/ee4f1a853f128fc96035152a0a006a40848de182) | `` ftb-app: init at 1.27.2 ``                                                 |
| [`ea6b46f7`](https://github.com/NixOS/nixpkgs/commit/ea6b46f7bde64f5ce341e6b248f3b4c664b4066c) | `` zed-editor: 0.183.11 -> 0.184.8 ``                                         |
| [`ae85fd88`](https://github.com/NixOS/nixpkgs/commit/ae85fd884ad4acce263fed7200e7372000a06825) | `` python312Packages.desktop-notifier: 6.1.0 -> 6.1.1 ``                      |
| [`dd01173e`](https://github.com/NixOS/nixpkgs/commit/dd01173e7e74fed1c86537ebb0992267346a68bb) | `` python312Packages.qcs-api-client: 0.25.5 -> 0.26.5 ``                      |
| [`9cad4afe`](https://github.com/NixOS/nixpkgs/commit/9cad4afe55f6e2f1d24d203f6104918d314ecb81) | `` python312Packages.devito: 4.8.15 -> 4.8.16 ``                              |
| [`5b4f8857`](https://github.com/NixOS/nixpkgs/commit/5b4f88574c7764d44f0f47a28b92951b76f579c2) | `` mergiraf: 0.6.0 -> 0.7.0 (#403299) ``                                      |
| [`cab3a98f`](https://github.com/NixOS/nixpkgs/commit/cab3a98f2ac576999e71d06999aa14f6f3bc1058) | `` exploitdb: 2025-04-23 -> 2025-05-01 ``                                     |
| [`bdd5c5dd`](https://github.com/NixOS/nixpkgs/commit/bdd5c5dd60cddfc52f534c9658133c8a92429dd2) | `` go-dnscollector: 1.6.0 -> 1.7.0 ``                                         |
| [`a313bb52`](https://github.com/NixOS/nixpkgs/commit/a313bb52817ffffa6546042ea7b546f0db28b046) | `` xreader: 4.2.5 -> 4.2.6 ``                                                 |
| [`70e115c1`](https://github.com/NixOS/nixpkgs/commit/70e115c1c015b6d3613635f03d1087cbb10c8130) | `` scalr-cli: 0.17.0 -> 0.17.1 ``                                             |
| [`2aa5d26c`](https://github.com/NixOS/nixpkgs/commit/2aa5d26c1a698ca3e0cd70af408c7b29903e4deb) | `` consul: 1.20.5 -> 1.20.6 ``                                                |
| [`b524ef13`](https://github.com/NixOS/nixpkgs/commit/b524ef1319816fbe7a13ba570c494907b1faff1a) | `` fastfetchMinimal: init at 2.42.0 ``                                        |
| [`c741f94a`](https://github.com/NixOS/nixpkgs/commit/c741f94abfe65087e4e2b50cd019f4aa4fcc9a34) | `` basex: 11.8 -> 11.9 ``                                                     |
| [`cc54c77b`](https://github.com/NixOS/nixpkgs/commit/cc54c77b73c591d4fc8e3975868c9be14d7bea54) | `` munin: add darwin to platforms ``                                          |
| [`bf1d1baa`](https://github.com/NixOS/nixpkgs/commit/bf1d1baa2754a4150cbcadc2d62b1cccad2cff01) | `` jjui: 0.8.5 -> 0.8.6 ``                                                    |
| [`22151db3`](https://github.com/NixOS/nixpkgs/commit/22151db37d2d2559c95b2f00a82f5a1c92f1bb51) | `` python312Packages.galois: 0.4.5 -> 0.4.6 ``                                |
| [`618519fb`](https://github.com/NixOS/nixpkgs/commit/618519fb96094881204f665a6f678a83888a1ffc) | `` hermitcli: 0.44.6 -> 0.44.8 ``                                             |
| [`5b779fab`](https://github.com/NixOS/nixpkgs/commit/5b779fab1effb31ad2b9c588ff12aa75039234d7) | `` mixxx: 2.5.0 -> specific commit ``                                         |
| [`eebe42d6`](https://github.com/NixOS/nixpkgs/commit/eebe42d6ba0b098315ff255b8be79d1baafc77a7) | `` xdg-desktop-portal-luminous: init at 0.1.8 ``                              |
| [`7561a1ec`](https://github.com/NixOS/nixpkgs/commit/7561a1ec8d11733762cfe57e108793f3498e29dd) | `` libdjinterop: 0.22.1 -> 0.24.3 ``                                          |