### PR TITLE
chore(flake/nixpkgs): `7a2622e2` -> `979daf34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746232882,
-        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`979daf34`](https://github.com/NixOS/nixpkgs/commit/979daf34c8cacebcd917d540070b52a3c2b9b16e) | `` roddhjav-apparmor-rules: 0-unstable-2025-04-25 -> 0-unstable-2025-05-03 `` |
| [`7b26bcd2`](https://github.com/NixOS/nixpkgs/commit/7b26bcd2d93a29a322372321f62694b64f60ddb9) | `` nixos/lk-jwt-service: Fix docs issues ``                                   |
| [`f2cdf605`](https://github.com/NixOS/nixpkgs/commit/f2cdf605c335dcd155a5f1f3d6ce825a0863f927) | `` nixos/livekit: Fix docs issues ``                                          |
| [`60d63205`](https://github.com/NixOS/nixpkgs/commit/60d63205def2ae3268f42e239cc58d594244e4eb) | `` klipperscreen: 0.4.4 -> 0.4.5, fix Network panel ``                        |
| [`2e1119b8`](https://github.com/NixOS/nixpkgs/commit/2e1119b85ea98abfbe6d2a17d932356b20260601) | `` python3Packages.pygccxml: 2.6.1 -> 3.0.2 ``                                |
| [`f60dbb66`](https://github.com/NixOS/nixpkgs/commit/f60dbb6688ee4bd133bfe96a421735361c4c58b5) | `` teleprompter: init at 1.0.1 ``                                             |
| [`04334ae9`](https://github.com/NixOS/nixpkgs/commit/04334ae9f7d36efe2fa888e68306bc67e607c5ff) | `` poliedros: init at 1.0.1 ``                                                |
| [`a6ca5040`](https://github.com/NixOS/nixpkgs/commit/a6ca5040121cb15c6a818e1281b7937b06dc4e87) | `` mopidy-argos: 1.15.0 -> 1.16.0 ``                                          |
| [`f21e4546`](https://github.com/NixOS/nixpkgs/commit/f21e4546e3ede7ae34d12a84602a22246b31f7e0) | `` tree-sitter-grammars.tree-sitter-netlinx: init ``                          |
| [`995fef5c`](https://github.com/NixOS/nixpkgs/commit/995fef5c210851915b7ef93718718ac9b7680562) | `` python3Packages.jupyter-book: disable tests that fail to close sqlite ``   |
| [`e462a75a`](https://github.com/NixOS/nixpkgs/commit/e462a75ad44682b4e8df740e33fca4f048e8aa11) | `` playwright: 1.50.0 -> 1.52.0 ``                                            |
| [`4f21f5e0`](https://github.com/NixOS/nixpkgs/commit/4f21f5e00b01745f2f2bbb07fc411ca2942a6acc) | `` doc: Add release notes for octave update ``                                |
| [`1672bf35`](https://github.com/NixOS/nixpkgs/commit/1672bf352f7f91af92b637a7fc9a1018b627269c) | `` librsb: mark as broken ``                                                  |
| [`ecec6403`](https://github.com/NixOS/nixpkgs/commit/ecec64036bafb3a86dfa52f6c20f191e5e6bab16) | `` librsb: no with lib; in meta ``                                            |
| [`98fa1e30`](https://github.com/NixOS/nixpkgs/commit/98fa1e301473f926e99cb6309f1d6e9e96895a18) | `` librsb: 1.2.0.10 -> 1.3.0.2 ``                                             |
| [`dfd35625`](https://github.com/NixOS/nixpkgs/commit/dfd35625a049c154effd51375ac51519c5cf1147) | `` octavePackages.ocl: mark as broken ``                                      |
| [`28a59449`](https://github.com/NixOS/nixpkgs/commit/28a59449bf50776ef563b317e1b8188c1e85370f) | `` octavePackages.ocl: 1.2.2 -> 1.2.3 ``                                      |
| [`1dc27975`](https://github.com/NixOS/nixpkgs/commit/1dc27975d1c106ccefcce2b9d7f3f75f16c3970f) | `` octavePackages.optim: mark as broken ``                                    |
| [`03446745`](https://github.com/NixOS/nixpkgs/commit/034467457dba4ea6f77847f04d08a2721484a3ab) | `` octavePackages.ltfat: mark as broken ``                                    |
| [`ec919913`](https://github.com/NixOS/nixpkgs/commit/ec91991380754fdff0072eaf8849980f9f437b64) | `` octavePackages.fits: mark as broken ``                                     |
| [`b715b871`](https://github.com/NixOS/nixpkgs/commit/b715b87197abb53bc914ff3740ce579c83a164f7) | `` octavePackages.econometrics: mark as broken ``                             |
| [`034725ee`](https://github.com/NixOS/nixpkgs/commit/034725ee33d1272ce41eea6be63ead1d6f72b1c6) | `` octavePackages.data-smoothing: mark as broken ``                           |
| [`7ed4bf49`](https://github.com/NixOS/nixpkgs/commit/7ed4bf4929ed8b53a5c529a41b3943e0e15bc7f7) | `` octavePackages.image-acquisition: 0.2.6 -> 0.3.0 ``                        |
| [`366af0fc`](https://github.com/NixOS/nixpkgs/commit/366af0fc93e8685de4c60009c68b349785e74dcb) | `` octavePackages: Update meta.homepage links ``                              |
| [`cbcb4b98`](https://github.com/NixOS/nixpkgs/commit/cbcb4b98a207e89b6f8e8d947b6c7ad5e0f8b22e) | `` octavePackages: no with lib; in meta ``                                    |
| [`a4f23f62`](https://github.com/NixOS/nixpkgs/commit/a4f23f6274a054231731cbfe28f3b7bd0e63c190) | `` octave: 9.4.0 -> 10.1.0 ``                                                 |
| [`4a48f9d4`](https://github.com/NixOS/nixpkgs/commit/4a48f9d497ef818a1f86157a5773dc9c55075e34) | `` LPCNet: unbreak on clang ``                                                |
| [`c417e768`](https://github.com/NixOS/nixpkgs/commit/c417e768aacfc8c11004e3f837b05748603b30af) | `` LPCNet: small semantic modernizing changes ``                              |
| [`972da783`](https://github.com/NixOS/nixpkgs/commit/972da7836895be2218b8f5d235c22a7dfbacdbf4) | `` spacecookie: enable networking on darwin ``                                |
| [`772f418a`](https://github.com/NixOS/nixpkgs/commit/772f418aa57dd380ad02dc2e72553fa2938d4ffb) | `` spacecookie: 1.0.0.2 -> 1.0.0.3 ``                                         |
| [`ffd4d43f`](https://github.com/NixOS/nixpkgs/commit/ffd4d43f7322f87e0a773d2d57fd921949cf9361) | `` nixos/module-list: run keep-sorted ``                                      |
| [`45be58d1`](https://github.com/NixOS/nixpkgs/commit/45be58d14773de8113ea189d702df09eee7b56dd) | `` nixos/module-list: keep them sorted ``                                     |
| [`f1b0c199`](https://github.com/NixOS/nixpkgs/commit/f1b0c199ea5d43bb5d02f7442b69b969f7da6e4b) | `` labels: run keep-sorted ``                                                 |
| [`e357e6e1`](https://github.com/NixOS/nixpkgs/commit/e357e6e1f941b01821a996924a81bcd365991085) | `` labels: keep them sorted ``                                                |
| [`88e40e42`](https://github.com/NixOS/nixpkgs/commit/88e40e42ef193e3fd76dc62b624ee8863627a53e) | `` nixos/services.paperless: add extra files OCR ``                           |
| [`a7966797`](https://github.com/NixOS/nixpkgs/commit/a796679769a894d60b73d8835e60b88ec45ae5ca) | `` jwx: 2.1.5 -> 3.0.1 ``                                                     |
| [`d6f75ac4`](https://github.com/NixOS/nixpkgs/commit/d6f75ac41e3d229811714b1546d7da09c981fffa) | `` git-mit: unbreak after github pr moved ``                                  |
| [`e2821ea7`](https://github.com/NixOS/nixpkgs/commit/e2821ea71c71870756f44388fd61d105d97f6f4f) | `` element-call: 0.9.0 -> 0.10.0 ``                                           |
| [`bdb6491f`](https://github.com/NixOS/nixpkgs/commit/bdb6491f5cd4910ad7efc0ab338d6039fdb79ae9) | `` forgejo: 11.0.0 -> 11.0.1 ``                                               |
| [`b302633d`](https://github.com/NixOS/nixpkgs/commit/b302633dbabdadc8dcf012cb2b21682ec8c28641) | `` python3Packages.neoteroi-mkdocs: fix tests on sandboxed darwin ``          |
| [`654aadff`](https://github.com/NixOS/nixpkgs/commit/654aadff7246cc776294c40e001f12774ce1afe7) | `` cargo-seek: init at 0.1.0 ``                                               |
| [`b20d91a4`](https://github.com/NixOS/nixpkgs/commit/b20d91a4898e7b5ab38fe546a88b098dbc0ec735) | `` pytyhon3Packages.essentials-openapi: fix tests on sandboxed darwin ``      |
| [`b5ac18a7`](https://github.com/NixOS/nixpkgs/commit/b5ac18a7acf1371af4b6abc7879d9d5d33a3148d) | `` pantheon.switchboard-plug-wacom: 8.0.0 -> 8.0.1 ``                         |
| [`d4a9346f`](https://github.com/NixOS/nixpkgs/commit/d4a9346f0e35e25313d33bacef500082b15142cc) | `` optinix: fix build ``                                                      |
| [`f92c8fa9`](https://github.com/NixOS/nixpkgs/commit/f92c8fa9dcbac039cb3ba2e39401de82b5bf900e) | `` opencolorio_1: use gitMinimal ``                                           |
| [`f1d239c8`](https://github.com/NixOS/nixpkgs/commit/f1d239c8859a4cf45ce549e88c4301977adc44a5) | `` opencolorio_1: modernize, add maintainer ``                                |
| [`161da110`](https://github.com/NixOS/nixpkgs/commit/161da1104c92bd9b37409fab6d1cca740ca6acbe) | `` python312Packages.uv-dynamic-versioning: 0.8.0 -> 0.8.2 ``                 |
| [`9b7746d4`](https://github.com/NixOS/nixpkgs/commit/9b7746d47714ac95669dac65545efb4464bd88f7) | `` ferron: 1.0.0 -> 1.2.0 ``                                                  |
| [`fbd49ee8`](https://github.com/NixOS/nixpkgs/commit/fbd49ee83e956de389edd9568340b5ad96295e1a) | `` ratman: fix src hash ``                                                    |
| [`18abb047`](https://github.com/NixOS/nixpkgs/commit/18abb047dfbc7d8da061be10b8fde187eac24100) | `` openclonk: adopt ``                                                        |
| [`0022de84`](https://github.com/NixOS/nixpkgs/commit/0022de84c1e399796cbf1dcfc6069f60aee2c69f) | `` openclonk: fix license ``                                                  |
| [`ed76a25a`](https://github.com/NixOS/nixpkgs/commit/ed76a25afe81d33fddc06a45721bc50a19366442) | `` openclonk: modernize ``                                                    |
| [`9e83b2af`](https://github.com/NixOS/nixpkgs/commit/9e83b2af85afed151219dc8c4b210012352fa075) | `` openclonk: remove cmakeFlags for gcc-unwrapped ``                          |
| [`04e1cd78`](https://github.com/NixOS/nixpkgs/commit/04e1cd780ead351327def20f3a760375461c5ffa) | `` openclonk: unstable-2023-10-30 -> 9.0-unstable-2025-01-11 ``               |
| [`52afe88d`](https://github.com/NixOS/nixpkgs/commit/52afe88d7068ba500ec23e35bac172d353e9a2b5) | `` kompute: unbreak by patching vulkan 1.4 support ``                         |
| [`58effd4f`](https://github.com/NixOS/nixpkgs/commit/58effd4f00787f053d3040167382ebb9cd46e43f) | `` degate: unbreak by pinning boost ``                                        |
| [`3a2b2968`](https://github.com/NixOS/nixpkgs/commit/3a2b29685533af75e754f2cbdd5631c00089856e) | `` openclonk: fix build ``                                                    |
| [`b7106a66`](https://github.com/NixOS/nixpkgs/commit/b7106a66b92e439b779ba75dd8fa40ebc145ae34) | `` stork: fix build by updating dependency ``                                 |
| [`1173897e`](https://github.com/NixOS/nixpkgs/commit/1173897ec5b0832d2093b68b8988544332461914) | `` openclonk: cleanup ``                                                      |
| [`92a214b2`](https://github.com/NixOS/nixpkgs/commit/92a214b27304a2a8058d0385c6c408d907cc3c6d) | `` python3Packages.jupyter-server-ydoc: 2.0.1 -> 2.0.2 ``                     |
| [`58dc90c9`](https://github.com/NixOS/nixpkgs/commit/58dc90c9f296d5a467cb0330d25635d4aced33e4) | `` maintainers: add ik-nz ``                                                  |
| [`556f9218`](https://github.com/NixOS/nixpkgs/commit/556f921837d67ea37b04a7f93ab3940c84ca61c6) | `` gdal: fix build ``                                                         |
| [`0aa989ed`](https://github.com/NixOS/nixpkgs/commit/0aa989eda7fadeac3be894ac79c47338de03f9a4) | `` python3Packages.yalexs-ble: 2.6.0 -> 3.0.0 ``                              |
| [`b526c6ef`](https://github.com/NixOS/nixpkgs/commit/b526c6ef88a3977857cf55c58d1339af95760f51) | `` artisan: 3.1.2 -> 3.1.4 ``                                                 |
| [`42190cb7`](https://github.com/NixOS/nixpkgs/commit/42190cb7a79177c04ec84d858d0e1e5f6c4e761e) | `` artisan: add updateScript ``                                               |
| [`eaead951`](https://github.com/NixOS/nixpkgs/commit/eaead951be1c4fcc79b91a68bd009e50a0fbc3ca) | `` just-lsp: 0.2.0 -> 0.2.1 ``                                                |
| [`041f5e02`](https://github.com/NixOS/nixpkgs/commit/041f5e02ff9964cc535b7aee0c4a620ed608e456) | `` python312Packages.mizani: 0.13.4 -> 0.13.5 ``                              |
| [`848fcac1`](https://github.com/NixOS/nixpkgs/commit/848fcac122e4eaa29bf8d7939bcb8b8e4473dcd7) | `` mythtv: fix src hash ``                                                    |
| [`a3980c78`](https://github.com/NixOS/nixpkgs/commit/a3980c78290d0bc6fae480c915f25cf411be66c1) | `` mythtv: prefer tag rather than rev for fetchFromGitHub ``                  |
| [`f4186aed`](https://github.com/NixOS/nixpkgs/commit/f4186aed0e2f1875a12c6545a3437c6a2d5afdd2) | `` python3Packages.docling-core: 2.28.0 -> 2.29.0 ``                          |
| [`40ffa623`](https://github.com/NixOS/nixpkgs/commit/40ffa62369b5c1db4d1de8739527a21386b1121c) | `` clusternet: downgrade go version to fix build ``                           |
| [`80399723`](https://github.com/NixOS/nixpkgs/commit/80399723929a1ed65ac407ccb4e8d0ffcc198e32) | `` python3Packages.sagemaker-core: 1.0.29 -> 1.0.31 ``                        |
| [`49c08e3c`](https://github.com/NixOS/nixpkgs/commit/49c08e3c0d48e3a9caf2a4d0bc5859ad8d2ce49c) | `` lazygit: 0.49.0 -> 0.50.0 ``                                               |
| [`79caba80`](https://github.com/NixOS/nixpkgs/commit/79caba80c050ae4cfb71b6898db6c56ae0d5b506) | `` action-validator: 0.6.0 -> 0.6.0-unstable-2025-02-16 ``                    |
| [`5a2f8889`](https://github.com/NixOS/nixpkgs/commit/5a2f8889e02634cdcb8ac5b75d6d655bf0bfd10c) | `` libchop: drop ``                                                           |
| [`08b2bab3`](https://github.com/NixOS/nixpkgs/commit/08b2bab3fd018e190b3955bc95fe6912db652387) | `` nix-converter: init at 0-unstable-2025-04-14 ``                            |
| [`8ce4abb1`](https://github.com/NixOS/nixpkgs/commit/8ce4abb100ed8140bc79d0be74bc4ad7fc3a73d6) | `` gmni: drop ``                                                              |
| [`e0541f42`](https://github.com/NixOS/nixpkgs/commit/e0541f42abdebc02d5b91f684218430c44a3f46b) | `` fastfetch: remove unused cmake options ``                                  |
| [`2c1a3811`](https://github.com/NixOS/nixpkgs/commit/2c1a3811e47695e6cbb39b1f46a4c77a2c46d0c8) | `` fastfetch: refactor dependencies more ``                                   |
| [`ec8b25b6`](https://github.com/NixOS/nixpkgs/commit/ec8b25b652947c7caf661503c18f7a3558e18c2a) | `` python313Packages.hieroglyph: fix build failure ``                         |
| [`27b7653b`](https://github.com/NixOS/nixpkgs/commit/27b7653bc65ce3f66a05fff698334a65bca47aee) | `` pokerth: unbreak by pinning boost ``                                       |
| [`d432c233`](https://github.com/NixOS/nixpkgs/commit/d432c233d260183b80703a63051237662b989416) | `` qpid-cpp: unbreak by pinning boost ``                                      |
| [`84a4b1ba`](https://github.com/NixOS/nixpkgs/commit/84a4b1ba3b3b23e400ab7a48f40bcb028537618e) | `` gersemi: 0.19.2 -> 0.19.3 ``                                               |
| [`a4c36799`](https://github.com/NixOS/nixpkgs/commit/a4c367999c708a45e47df66eb033dbc1a454af00) | `` grap: unbreak by pinning boost ``                                          |
| [`1356199c`](https://github.com/NixOS/nixpkgs/commit/1356199cd36fee288f24ebc32ffc011bf1e9fd4b) | `` zegrapher: unbreak by pinning boost ``                                     |
| [`cf60bcfd`](https://github.com/NixOS/nixpkgs/commit/cf60bcfd4c891caed37bb53cc247a50a0e152f41) | `` python312Packages.pymilvus: 2.5.7 -> 2.5.8 ``                              |
| [`0010ccd2`](https://github.com/NixOS/nixpkgs/commit/0010ccd2b594c17bda5769c77a3a421f8a662fc9) | `` terragrunt: 0.77.22 -> 0.78.0 ``                                           |
| [`640193fb`](https://github.com/NixOS/nixpkgs/commit/640193fbb308025f906fc0e19343e16fd6d0dd80) | `` python3Packages.h5io: 0.2.1 -> 0.2.5 ``                                    |
| [`b78b6aa8`](https://github.com/NixOS/nixpkgs/commit/b78b6aa8b11468c9c68c99bac19baaac0c9127f7) | `` pantheon.xdg-desktop-portal-pantheon: 8.0.0 -> 8.0.1 ``                    |
| [`9f52e7ae`](https://github.com/NixOS/nixpkgs/commit/9f52e7ae3ba6d453da169fc224b3e07a58f36a05) | `` act: 0.2.76 -> 0.2.77 ``                                                   |
| [`bb117f1e`](https://github.com/NixOS/nixpkgs/commit/bb117f1e040d4d7119f52e70c2fcefa114785923) | `` flexget: 3.15.37 -> 3.15.38 ``                                             |
| [`9af52ca2`](https://github.com/NixOS/nixpkgs/commit/9af52ca2475674bed3b3aca5962546613dfdf892) | `` beeper: 4.0.640 -> 4.0.661 ``                                              |
| [`66eff6f8`](https://github.com/NixOS/nixpkgs/commit/66eff6f896e29f981e8c4f9845efeefca5b5f5e9) | `` pantheon.switchboard-plug-about: 8.2.0 -> 8.2.1 ``                         |
| [`e6b21afb`](https://github.com/NixOS/nixpkgs/commit/e6b21afbba674d5584f985a00cdebe7405692621) | `` cobang: 1.6.1 -> 1.6.2 ``                                                  |
| [`67a22705`](https://github.com/NixOS/nixpkgs/commit/67a22705e746ca7026561a950f925d8f98d98929) | `` nixos/graphite: use lib.getExe ``                                          |
| [`9ce87bd9`](https://github.com/NixOS/nixpkgs/commit/9ce87bd9118e49fb167699e3837a3293818f660e) | `` nixos/graphite: fix django-admin executable name ``                        |
| [`a719fb17`](https://github.com/NixOS/nixpkgs/commit/a719fb17be95abe2af0705351d46ec070a2fa9d4) | `` python313Packages.pystemd: modernize ``                                    |
| [`a4d49fb2`](https://github.com/NixOS/nixpkgs/commit/a4d49fb2a1159b4fdebe7f15d2bd0e60d37b0ffd) | `` stylelint: 16.19.0 -> 16.19.1 ``                                           |
| [`ba4935b9`](https://github.com/NixOS/nixpkgs/commit/ba4935b9cb914b0697147ffd71a376ea37eb7a36) | `` python3Packages.aiohttp-swagger: remove tests ``                           |
| [`914592a8`](https://github.com/NixOS/nixpkgs/commit/914592a83e2bdf11333301e191c64edcc9582207) | `` python3Packages.aiohttp-swagger: modernize ``                              |
| [`840a221d`](https://github.com/NixOS/nixpkgs/commit/840a221d30ad127e70fd159781553b19ac2ad5d8) | `` python3Packages.py-stringmatching: fixes ``                                |
| [`68d4d5da`](https://github.com/NixOS/nixpkgs/commit/68d4d5da4fc968d26042eb90be53630065d3333d) | `` mkvtoolnix: 91.0 -> 92.0 ``                                                |
| [`3ae573b0`](https://github.com/NixOS/nixpkgs/commit/3ae573b0cb30c85f090cf8de98c36748acf05ea0) | `` python3Packages.nbsphinx: fix build ``                                     |
| [`d96d01d7`](https://github.com/NixOS/nixpkgs/commit/d96d01d7aa2d1193516e1382ce053ecee297027c) | `` python313Packages.pystemd: unbreak ``                                      |
| [`c07fab49`](https://github.com/NixOS/nixpkgs/commit/c07fab49b1b46e7f5a939dced7128e509d010f28) | `` nb-cli: expand pythonImportsCheck ``                                       |
| [`2352b85c`](https://github.com/NixOS/nixpkgs/commit/2352b85c437736a0c5841c27f90911e15400bc35) | `` nb-cli: unbreak by relaxin watchfiles ``                                   |
| [`29f4c3cf`](https://github.com/NixOS/nixpkgs/commit/29f4c3cf9460428908a4904b3510b5ff6c026e82) | `` kaggle: unbreak ``                                                         |
| [`1143516f`](https://github.com/NixOS/nixpkgs/commit/1143516fa7f629a7bba2da402a5f2142c1bc4441) | `` iotas: 0.9.5 -> 0.11.0 ``                                                  |
| [`92b7a63b`](https://github.com/NixOS/nixpkgs/commit/92b7a63b3afa2ab97fbd25bc545f48e53f60987e) | `` steamback: modernize ``                                                    |
| [`e1ccec0d`](https://github.com/NixOS/nixpkgs/commit/e1ccec0dea049bfa119f0052d429e910e94921f4) | `` steamback: unbreak by relaxing psutil ``                                   |
| [`d05af813`](https://github.com/NixOS/nixpkgs/commit/d05af8132534d025653e1a1d1a7246720802ecd8) | `` cpu_features: 0.9.0 -> 0.10.0 ``                                           |
| [`49a22b2e`](https://github.com/NixOS/nixpkgs/commit/49a22b2e6dd1c795779ef9823a8777283b98c2fe) | `` libcmatrix: unbreak on darwin ``                                           |
| [`f424399a`](https://github.com/NixOS/nixpkgs/commit/f424399a6279b3ae05e905ccf75522be61261c2c) | `` olm: unbreak on clang ``                                                   |
| [`33d0a2a6`](https://github.com/NixOS/nixpkgs/commit/33d0a2a6e38c4800c24a87d812318cc6af32bffd) | `` vscode-extensions.yy0931.vscode-sqlite3-editor: init at 1.0.207 ``         |
| [`c350c5d8`](https://github.com/NixOS/nixpkgs/commit/c350c5d83e098abea634a6ea6b76ac582c2e6011) | `` maintainers: add ch4og ``                                                  |
| [`d1f8e253`](https://github.com/NixOS/nixpkgs/commit/d1f8e25339d1c2acb76e965a0f9252559a6e9877) | `` poetry: disable flaky threading_* tests ``                                 |
| [`7754699a`](https://github.com/NixOS/nixpkgs/commit/7754699a8f3fe8c4bf3899101a7d447747c55580) | `` gradle: fix toolchains test ``                                             |
| [`ebe9d746`](https://github.com/NixOS/nixpkgs/commit/ebe9d746a2499b7415565a19835475938371c895) | `` vinegar: fix missing wine binary from PATH ``                              |
| [`d4f59b60`](https://github.com/NixOS/nixpkgs/commit/d4f59b601f38106454a4b7e59e8ceabcdabc9724) | `` vinegar: use finalAttrs ``                                                 |
| [`b9c6199c`](https://github.com/NixOS/nixpkgs/commit/b9c6199cd808ab43d4ee070f207648fe89453b93) | `` ocl-icd: fix cross to musl ``                                              |
| [`11f6058b`](https://github.com/NixOS/nixpkgs/commit/11f6058b4f792ad5750ccc0ca7ecad3e63fb5a28) | `` gokapi: apply patch to allow builds with go 1.24 ``                        |
| [`b36eafbb`](https://github.com/NixOS/nixpkgs/commit/b36eafbb8e4467918b213776011c14f4a4511c75) | `` vice: fix pulseaudio support missing (#403507) ``                          |