### PR TITLE
chore(flake/nixpkgs): `dda3dcd3` -> `d89fc19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746663147,
-        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`406ea5c0`](https://github.com/NixOS/nixpkgs/commit/406ea5c089b5999f0b94a8ebb60dfd7f4fb876c4) | `` CONTRIBUTING: allow fetching unaccepted changes if the URL is stable ``             |
| [`8e551be5`](https://github.com/NixOS/nixpkgs/commit/8e551be5f1c795a79ca2ea7306efb2ef1985f826) | `` nixos/graphics: don't mark `package` options as internal ``                         |
| [`23b69b2b`](https://github.com/NixOS/nixpkgs/commit/23b69b2bfbc5a88347000e252fdc31eaa99c5e4b) | `` libretro.mame: 0-unstable-2025-04-01 -> 0-unstable-2025-05-01 ``                    |
| [`ce8e2c97`](https://github.com/NixOS/nixpkgs/commit/ce8e2c978b9417d6fae52cc6360ff7bee6ef1ae8) | `` apparmor: fix cross for different bit depths between build and host ``              |
| [`10efa872`](https://github.com/NixOS/nixpkgs/commit/10efa87252f948c3a0c75ff79637a9fa1946d201) | `` samtools_0_1_19: drop ``                                                            |
| [`6dafa963`](https://github.com/NixOS/nixpkgs/commit/6dafa963f8074ae9a5e0fb81a99a81a17d10f14a) | `` ferron: 1.2.0 -> 1.3.0 ``                                                           |
| [`02c22c23`](https://github.com/NixOS/nixpkgs/commit/02c22c235870529fe566a9ad6056862ae3dde558) | `` quickserve: drop ``                                                                 |
| [`4f4d09f6`](https://github.com/NixOS/nixpkgs/commit/4f4d09f68d3e205109bd52128f4f0d68894f56ca) | `` omping: drop ``                                                                     |
| [`80bfdb15`](https://github.com/NixOS/nixpkgs/commit/80bfdb151694fd4f0852e588902393ae422c0941) | `` ptask: drop ``                                                                      |
| [`88eae738`](https://github.com/NixOS/nixpkgs/commit/88eae73897d681c24fabfcf198928375de5645b2) | `` cargo-bolero: 0.13.2 -> 0.13.3 (#405869) ``                                         |
| [`2b9c4e45`](https://github.com/NixOS/nixpkgs/commit/2b9c4e45cc93861f9250efd0ae3e72706503c3a4) | `` psstop: drop ``                                                                     |
| [`86534aaf`](https://github.com/NixOS/nixpkgs/commit/86534aafc36a7fcb7f90e83bb44e924f0c89acb6) | `` kdePackages.karousel: 0.12 -> 0.13 ``                                               |
| [`cc357fbf`](https://github.com/NixOS/nixpkgs/commit/cc357fbf4affc256f19fb7c807f8f1b94da2a82b) | `` yaziPlugins: yazi-rs homepage population ``                                         |
| [`95fa8bd4`](https://github.com/NixOS/nixpkgs/commit/95fa8bd4f48d798b8e82fcb2cf4b201544409837) | `` yaziPlugins.smart-paste: init at 0-unstable-2025-04-27 ``                           |
| [`3a12cf61`](https://github.com/NixOS/nixpkgs/commit/3a12cf6135bfc16d38f0e80e4019158431a63928) | `` vimPlugins.avante-nvim: 0.0.23-unstable-2025-05-09 -> 0.0.23-unstable-2025-05-10 `` |
| [`4b6f7955`](https://github.com/NixOS/nixpkgs/commit/4b6f79551348ca6dc2fb3a54f12c86b7e15ee04f) | `` homepage-dashboard: unmark as broken on darwin ``                                   |
| [`3a9db264`](https://github.com/NixOS/nixpkgs/commit/3a9db26426bceda4769b77d722ca129370d0bb01) | `` yaziPlugins.mediainfo: 25.2.7-unstable-2025-04-05 -> 25.2.7-unstable-2025-04-17 ``  |
| [`e1dadb0c`](https://github.com/NixOS/nixpkgs/commit/e1dadb0c51972d9401924a54f6fb37a8aeac80dc) | `` python3Packages.flowjax: 17.1.1 -> 17.1.2 ``                                        |
| [`b08c07c4`](https://github.com/NixOS/nixpkgs/commit/b08c07c4fbf99907a8ac44a9eca632875809fd3b) | `` libretro.puae: 0-unstable-2025-04-22 -> 0-unstable-2025-05-10 ``                    |
| [`7dd8c5b6`](https://github.com/NixOS/nixpkgs/commit/7dd8c5b602de90f8fb8d7381438fb4ab12b100d7) | `` unifi8: drop ``                                                                     |
| [`89d314df`](https://github.com/NixOS/nixpkgs/commit/89d314dfbdaca17c5ba2aed10c389ffb9cef6b40) | `` premake3: drop ``                                                                   |
| [`f3bd454d`](https://github.com/NixOS/nixpkgs/commit/f3bd454d3556eea6f2218146424fb620204e2bfa) | `` python3Packages.casbin: 1.41.0 -> 1.43.0 ``                                         |
| [`8f426128`](https://github.com/NixOS/nixpkgs/commit/8f426128c45b89c0c1c5f8a7980c330a1b52aca0) | `` grafana-alloy: 1.8.2 -> 1.8.3 ``                                                    |
| [`54608c53`](https://github.com/NixOS/nixpkgs/commit/54608c53f880969b09217ce092400e7764cf482f) | `` ghostfolio: 2.156.0 -> 2.161.0 ``                                                   |
| [`520534e5`](https://github.com/NixOS/nixpkgs/commit/520534e533fee6f2460632d0b8e7e7a2617e1b2b) | `` ventoy*: mark unfree, mark insecure ``                                              |
| [`fba4b8d5`](https://github.com/NixOS/nixpkgs/commit/fba4b8d5bfe57f16606f932abbd531678fd0c0a2) | `` python3Packages.llama-index-graph-stores-nebula: 0.4.1 -> 0.4.2 ``                  |
| [`813ce4bc`](https://github.com/NixOS/nixpkgs/commit/813ce4bcd00ee9760a254cc388d2e949a4c257de) | `` pgf1: drop ``                                                                       |
| [`17b8d165`](https://github.com/NixOS/nixpkgs/commit/17b8d165fa84aa79ee3ce18d30b0c0f4fbdcff9f) | `` n98-magerun2: 8.0.0 -> 8.1.1 ``                                                     |
| [`71f07d68`](https://github.com/NixOS/nixpkgs/commit/71f07d6854ee13808a981b50243e11fd57fc298a) | `` lxqt.lxqt-build-tools: remove unused dependency on pcre ``                          |
| [`4719d31e`](https://github.com/NixOS/nixpkgs/commit/4719d31ebab750951f891963216c44c0e1ce4ba0) | `` noah: drop ``                                                                       |
| [`847f7769`](https://github.com/NixOS/nixpkgs/commit/847f7769f98d5bfcc45edcea9f688de6dd5a6144) | `` python3Packages.jianpu-ly: add meta.changelog ``                                    |
| [`c365f283`](https://github.com/NixOS/nixpkgs/commit/c365f2831e3427304229b1c8da77bf0d42b2865b) | `` python3Packages.hy: 1.0.0 -> 1.1.0 ``                                               |
| [`48413752`](https://github.com/NixOS/nixpkgs/commit/484137521e3981a92ee43064562078aad2928a9e) | `` python3Packages.python-docs-theme: 2025.2 -> 2025.4.1 ``                            |
| [`fe741c3a`](https://github.com/NixOS/nixpkgs/commit/fe741c3acf7388065b1864784bc2924761a6aa8b) | `` python3Packages.llama-cloud: 0.1.19 -> 0.1.21 ``                                    |
| [`e4bae9b0`](https://github.com/NixOS/nixpkgs/commit/e4bae9b0b146391f4dfe6a839302664132780c71) | `` python3Packages.reolink-aio: 0.13.2 -> 0.13.3 ``                                    |
| [`a15e88b5`](https://github.com/NixOS/nixpkgs/commit/a15e88b58b50e1d72a66f377a115e92d74b20d89) | `` vimPlugins.avante-nvim: v0.0.23 -> 0.0.23-unstable-2025-05-09 ``                    |
| [`984126dd`](https://github.com/NixOS/nixpkgs/commit/984126ddb194a6f943fc64a1059ad5c54a92accc) | `` python3Packages.universal-silabs-flasher: 0.0.30 -> 0.0.31 ``                       |
| [`62dac8ab`](https://github.com/NixOS/nixpkgs/commit/62dac8ab6ae3b4759c84780b2c884b04da0961e3) | `` beam26Packages.ex_doc: 0.37.3 -> 0.38.0 ``                                          |
| [`b3434b49`](https://github.com/NixOS/nixpkgs/commit/b3434b499c74b0d0b1f58f07156f49e26ae173e9) | `` moonlight-qt: avoid linking to both SDL2_classic and sdl3 ``                        |
| [`6610d576`](https://github.com/NixOS/nixpkgs/commit/6610d57665ebbf939ba2ff51f369197ae5f40bc8) | `` dap: drop ``                                                                        |
| [`14753ecd`](https://github.com/NixOS/nixpkgs/commit/14753ecd70e12a8a854c5be7eda47c64fb80ecbf) | `` n98-magerun2: use php 8.3 ``                                                        |
| [`3bb8fa02`](https://github.com/NixOS/nixpkgs/commit/3bb8fa02e657bf0d87727ccab12e30c2e11a057b) | `` coqPackages.mathcomp-infotheo: 0.9.1 -> 0.9.3 ``                                    |
| [`9cac65b6`](https://github.com/NixOS/nixpkgs/commit/9cac65b6dbae178e1bd87b0ca7545db76d85a45a) | `` coqPackages.mathcomp-algebra-tactics: 1.2.4 -> 1.2.5 ``                             |
| [`3591786e`](https://github.com/NixOS/nixpkgs/commit/3591786efeecb236bbb0878a68b249eda9618e2a) | `` coqPackages.mathcomp-tarjan: 1.0.2 -> 1.0.3 ``                                      |
| [`0e63dbec`](https://github.com/NixOS/nixpkgs/commit/0e63dbec831f7650b695ad6a6d587608b0a110f8) | `` coqPackages.reglang: 1.2.1 -> 1.2.2 ``                                              |
| [`94394c33`](https://github.com/NixOS/nixpkgs/commit/94394c3309606c1eff278b5f75a04a2f467e1bfd) | `` coqPackages.ssprove: 0.2.3 -> 0.2.4 ``                                              |
| [`c374d60d`](https://github.com/NixOS/nixpkgs/commit/c374d60d5f44c8e45880db950df1dc6f1ff35819) | `` coqPackages.ssprove: fix ``                                                         |
| [`5f5e1293`](https://github.com/NixOS/nixpkgs/commit/5f5e129328e807b3aa981fe2e66909a7d9554870) | `` coqPackages.mathcomp-analysis: 1.9.0 -> 1.11.0 ``                                   |
| [`d87c8735`](https://github.com/NixOS/nixpkgs/commit/d87c87358f908d516ebf9d90f4d0be2c4ad76363) | `` coqPackages.deriving: 0.2.1 -> 0.2.2 ``                                             |
| [`0d66b565`](https://github.com/NixOS/nixpkgs/commit/0d66b5655675b829b02afe73d2535dabcd6c69d8) | `` coqPackages.graph-theory: 0.9.4 -> 0.9.6 ``                                         |
| [`1119b156`](https://github.com/NixOS/nixpkgs/commit/1119b1569d17206c0e28af73df3c4b7e18846da7) | `` coqPackages.multinomials: 2.3.0 -> 2.4.0 ``                                         |
| [`bc496691`](https://github.com/NixOS/nixpkgs/commit/bc49669183cd94533ad347eb97309642ff714eda) | `` coqPackages.finmap: 2.1.0 -> 2.2.0 ``                                               |
| [`53b178a1`](https://github.com/NixOS/nixpkgs/commit/53b178a1f249c934c8f97bf954f93d8ac7093651) | `` coqPackages.odd-order: 2.1.0 -> 2.2.0 ``                                            |
| [`d7fd0525`](https://github.com/NixOS/nixpkgs/commit/d7fd05259c8c517f9fa2cd60056a3cd7e34bdb06) | `` coqPackages.gaia: 2.2 -> 2.3 ``                                                     |
| [`cb817bb9`](https://github.com/NixOS/nixpkgs/commit/cb817bb9db32a89dbc6b9546f5ee643d4ad6f7d9) | `` coqPackages.mathcomp-real-closed: 2.0.2 -> 2.0.3 ``                                 |
| [`935b1cc6`](https://github.com/NixOS/nixpkgs/commit/935b1cc6babe457211b7821ab267b3155f330b6f) | `` coqPackages.fourcolor: 1.4.0 -> 1.4.1 ``                                            |
| [`42dba13f`](https://github.com/NixOS/nixpkgs/commit/42dba13fa6c671929accc32041c9299f2bf6d8ff) | `` coqPackages.mathcomp: 2.3.0 -> 2.4.0 ``                                             |
| [`a394a72a`](https://github.com/NixOS/nixpkgs/commit/a394a72a6cfa7e5c4e1eb0b396f001285d4abff6) | `` frei0r: remove unused pcre dependency ``                                            |
| [`91df2cd7`](https://github.com/NixOS/nixpkgs/commit/91df2cd7d672a316ed40ad0aacfd8a22904d13a1) | `` jp-zip-codes: 0-unstable-2025-04-01 -> 0-unstable-2025-05-01 ``                     |
| [`5f48f53a`](https://github.com/NixOS/nixpkgs/commit/5f48f53a303d41a116b1241022fa79d055983b5a) | `` python313Packages.types-awscrt: 0.26.1 -> 0.27.1 ``                                 |
| [`5b52f271`](https://github.com/NixOS/nixpkgs/commit/5b52f2715260457e07fc20eed2e5f59a5e5616b5) | `` python313Packages.modbus-tk: 1.1.4 -> 1.1.5 ``                                      |
| [`7273984a`](https://github.com/NixOS/nixpkgs/commit/7273984afda058e7b71965dc35497fa6e8e78fa8) | `` python313Packages.tencentcloud-sdk-python: 3.0.1374 -> 3.0.1375 ``                  |
| [`d82d668e`](https://github.com/NixOS/nixpkgs/commit/d82d668e6d13c35fcb1163b99fdc7b061293836d) | `` python313Packages.tencentcloud-sdk-python: 3.0.1373 -> 3.0.1374 ``                  |
| [`6998c3d4`](https://github.com/NixOS/nixpkgs/commit/6998c3d4b723cf3efb78742a07be13f922dc3600) | `` python313Packages.publicsuffixlist: 1.0.2.20250503 -> 1.0.2.20250509 ``             |
| [`dbc17fa0`](https://github.com/NixOS/nixpkgs/commit/dbc17fa048ee1f75496e0fbe2da48f27ff4c49dc) | `` python313Packages.meshtastic: 2.6.2 -> 2.6.3 ``                                     |
| [`64ddb9b0`](https://github.com/NixOS/nixpkgs/commit/64ddb9b040f959a95eba733caf9d5fbbfdd6e8d1) | `` python313Packages.holidays: 0.71 -> 0.72 ``                                         |
| [`b93976ee`](https://github.com/NixOS/nixpkgs/commit/b93976ee6df2bcc70a71ecf7318a7bbf9fb95334) | `` antimatter-dimensions: 0-unstable-2024-10-16 -> 0-unstable-2025-05-08 ``            |
| [`b8743c7b`](https://github.com/NixOS/nixpkgs/commit/b8743c7bf38f84bf13b143b1c6de22f89b0fba32) | `` python313Packages.easyenergy: 2.1.2 -> 2.2.0 ``                                     |
| [`1b36d054`](https://github.com/NixOS/nixpkgs/commit/1b36d05438cedb5faa81f6442aab793d7707d8c0) | `` python313Packages.cyclopts: 3.15.0 -> 3.16.0 ``                                     |
| [`b5dabd4a`](https://github.com/NixOS/nixpkgs/commit/b5dabd4acc8d29bf3ac8a52fbd781df0b8cb33bb) | `` python313Packages.boto3-stubs: 1.38.12 -> 1.38.13 ``                                |
| [`5424be23`](https://github.com/NixOS/nixpkgs/commit/5424be232d39e6095b3c60f5d6b0179d77afafbc) | `` python313Packages.botocore-stubs: 1.38.12 -> 1.38.13 ``                             |
| [`c7d8d460`](https://github.com/NixOS/nixpkgs/commit/c7d8d460e13465e90b7a7bf4f977e93f0f34cfbc) | `` python312Packages.mypy-boto3-workspaces: 1.38.0 -> 1.38.13 ``                       |
| [`db16bd86`](https://github.com/NixOS/nixpkgs/commit/db16bd86488bb483356e66b2258c15bd51c6c7f2) | `` python312Packages.mypy-boto3-synthetics: 1.38.11 -> 1.38.13 ``                      |
| [`73c93d3e`](https://github.com/NixOS/nixpkgs/commit/73c93d3e7eb6af09eda27f88f73efec5c3a0e047) | `` python312Packages.mypy-boto3-logs: 1.38.6 -> 1.38.13 ``                             |
| [`f8d8c4d4`](https://github.com/NixOS/nixpkgs/commit/f8d8c4d4e68191a552f6614c6835157feac59abd) | `` python312Packages.mypy-boto3-athena: 1.38.0 -> 1.38.13 ``                           |
| [`d00b1944`](https://github.com/NixOS/nixpkgs/commit/d00b194428f7ce1eda3e0b07d6a14e45484abf49) | `` python312Packages.angr: 9.2.153 -> 9.2.154 ``                                       |
| [`1a4a32bd`](https://github.com/NixOS/nixpkgs/commit/1a4a32bd335a0e85f55f09c92cfe1b0abae7f732) | `` python313Packages.cle: 9.2.153 -> 9.2.154 ``                                        |
| [`c7d51919`](https://github.com/NixOS/nixpkgs/commit/c7d519193d30ddbe042becd75aa1691f8707f75a) | `` python313Packages.claripy: 9.2.153 -> 9.2.154 ``                                    |
| [`5bcdd669`](https://github.com/NixOS/nixpkgs/commit/5bcdd6697ccce85351355cd70e3446a27e503f3f) | `` python313Packages.pyvex: 9.2.153 -> 9.2.154 ``                                      |
| [`3126a3ed`](https://github.com/NixOS/nixpkgs/commit/3126a3ed3c3dd2eb10b1b6097ad9bb9766eda65b) | `` python313Packages.ailment: 9.2.153 -> 9.2.154 ``                                    |
| [`97e31685`](https://github.com/NixOS/nixpkgs/commit/97e31685830ef35353d19527d0e26b0ce5611251) | `` python313Packages.archinfo: 9.2.153 -> 9.2.154 ``                                   |
| [`05762e33`](https://github.com/NixOS/nixpkgs/commit/05762e33772bdd8fd8e8144a69a7cf361ba4a81f) | `` kdePackages: Frameworks 6.13 -> 6.14 ``                                             |
| [`d1e0e1b8`](https://github.com/NixOS/nixpkgs/commit/d1e0e1b88bc6e9013d0dbfe2731885d450c0908f) | `` tinfoil-cli: 0.0.11 -> 0.0.13 ``                                                    |
| [`90c0380c`](https://github.com/NixOS/nixpkgs/commit/90c0380c8bb4de642ba29995f26483060c0a53d8) | `` kubetui: 1.7.0 -> 1.7.1 ``                                                          |
| [`841728f7`](https://github.com/NixOS/nixpkgs/commit/841728f7c4d6fa14bb70184f9b354b8a03d9cb50) | `` rebuilderd: 0.22.1 -> 0.23.1 ``                                                     |
| [`c83285ad`](https://github.com/NixOS/nixpkgs/commit/c83285ade328a12ff2477d9345714e0dfb16d28b) | `` qmmp: move to pkgs/by-name ``                                                       |
| [`30995f2e`](https://github.com/NixOS/nixpkgs/commit/30995f2e7e1c2d618e74a4a64b98a472a6b6ae41) | `` qmmp: 2.1.8 -> 2.2.5 ``                                                             |
| [`09d70d93`](https://github.com/NixOS/nixpkgs/commit/09d70d93ce5ce155bbeaaf616f46f7c61218c2ed) | `` deconz: 2.29.5 -> 2.30.2 ``                                                         |
| [`cbf7bcad`](https://github.com/NixOS/nixpkgs/commit/cbf7bcade74a9357f0639ac19db30ccabea66ddb) | `` halo: 2.20.19 -> 2.20.20 ``                                                         |
| [`0c6ffe25`](https://github.com/NixOS/nixpkgs/commit/0c6ffe2504403175dd2d53a6f60b9e2577ce5bf6) | `` aider-chat: add maintainer ``                                                       |
| [`9cba8f13`](https://github.com/NixOS/nixpkgs/commit/9cba8f1356423f4a688b630cca4369d382abe119) | `` aider-chat: enable for python 3.10 and 3.11 ``                                      |
| [`8a4e9efc`](https://github.com/NixOS/nixpkgs/commit/8a4e9efc859b24b5398e663a4d3ca584560283fa) | `` aider-chat: 0.82.2 -> 0.83.0 ``                                                     |
| [`066b2a31`](https://github.com/NixOS/nixpkgs/commit/066b2a319c736c6bb213b4569674f332b5f58651) | `` python3Packages.oslex: init at 0.1.3 ``                                             |
| [`0770a4b3`](https://github.com/NixOS/nixpkgs/commit/0770a4b332129874cbe960d36c0388a5f656ef78) | `` python3Packages.mslex: init at 1.3.0 ``                                             |
| [`df45ccd2`](https://github.com/NixOS/nixpkgs/commit/df45ccd22b79d7537e2edb47cfe25524286d995d) | `` vscode-extensions.github.copilot: 1.309.0 -> 1.317.0 ``                             |
| [`dab40555`](https://github.com/NixOS/nixpkgs/commit/dab4055530793b8753e3990a109138839c5c4b09) | `` python3Packages.swcgeom: init at 0.19.3 ``                                          |
| [`22691a7f`](https://github.com/NixOS/nixpkgs/commit/22691a7f99e10f7a000295cd52681ba0e58331ca) | `` clash-meta: 1.19.5 -> 1.19.6 ``                                                     |
| [`6b89a786`](https://github.com/NixOS/nixpkgs/commit/6b89a7863ae7cf6b277466fb48d6f95b8b7e6f91) | `` dwlb: 0-unstable-2024-05-16 -> 0-unstable-2025-05-05 ``                             |
| [`a2e79da7`](https://github.com/NixOS/nixpkgs/commit/a2e79da76c39c94b0cbadedd20ecd44b9ae90243) | `` foundry: 1.0.0 -> 1.1.0 ``                                                          |
| [`91f06db7`](https://github.com/NixOS/nixpkgs/commit/91f06db7c872bfbd60747344f4f887c133c4a49c) | `` open-relay-typefaces: init at 2025-03-20, subsumes kreative-square-fonts ``         |
| [`7930c1ec`](https://github.com/NixOS/nixpkgs/commit/7930c1ec502b761a54ec7281c5080fc9e52215e9) | `` python312Packages.pynmeagps: 1.0.49 → 1.0.50 ``                                     |
| [`f7e7748d`](https://github.com/NixOS/nixpkgs/commit/f7e7748db18858b93acc243d46c3dc03b49f8555) | `` netbird: 0.43.2 -> 0.43.3 ``                                                        |
| [`37c00e14`](https://github.com/NixOS/nixpkgs/commit/37c00e14ee25c31e13e69324228556b4cf67f127) | `` python3Packages.oci: 2.142.0 -> 2.151.0 ``                                          |
| [`df3ebb63`](https://github.com/NixOS/nixpkgs/commit/df3ebb633cc825033080791d7ad3004828da80da) | `` yq-go: 4.45.1 -> 4.45.3 ``                                                          |
| [`c2640da8`](https://github.com/NixOS/nixpkgs/commit/c2640da88cb7342c9491c733cd9476372e8bf91d) | `` i-pi: 3.1.2 -> 3.1.4 ``                                                             |
| [`c2429f4a`](https://github.com/NixOS/nixpkgs/commit/c2429f4a99cbfcd2352ca33a21abb61a65891f25) | `` python3Packages.internetarchive: 5.3.0 -> 5.4.0 ``                                  |
| [`7a508024`](https://github.com/NixOS/nixpkgs/commit/7a5080241174cd241809b1091af6e2b589ff2440) | `` libsupermesh: init at 2025.3.0 ``                                                   |
| [`7406f719`](https://github.com/NixOS/nixpkgs/commit/7406f719e6216ac8614fd5028da9554ec4d9d4b3) | `` myks: 4.8.1 -> 4.8.2 ``                                                             |
| [`c8bfdac6`](https://github.com/NixOS/nixpkgs/commit/c8bfdac678fbfa3103be45b356780a0eada37b33) | `` python3Packages.pylit: init at 0.8.0 ``                                             |
| [`48ac68a1`](https://github.com/NixOS/nixpkgs/commit/48ac68a12394e48d1372f8a126a60ea989f78cc9) | `` cargo-careful: 0.4.3 -> 0.4.5 ``                                                    |
| [`1f2151d4`](https://github.com/NixOS/nixpkgs/commit/1f2151d43786845c768ffc01543639acaecff4ad) | `` python3Packages.json-schema-for-humans: 1.3.4 -> 1.4.1 ``                           |
| [`9d2e92d7`](https://github.com/NixOS/nixpkgs/commit/9d2e92d78be59ba328459444856f2376ad35b682) | `` doc: Clarify that fetchPypi is not preferred for python ``                          |
| [`9f4d5af6`](https://github.com/NixOS/nixpkgs/commit/9f4d5af6082f7396e994bfb4729aa399f9246c84) | `` anubis: 1.17.1 -> 1.18.0 ``                                                         |
| [`78b41f22`](https://github.com/NixOS/nixpkgs/commit/78b41f226da707e9b7ff97be5b98cca0d2f1d483) | `` python3Packages.oras: 0.2.29 -> 0.2.31 ``                                           |
| [`cc149521`](https://github.com/NixOS/nixpkgs/commit/cc149521a060687bfd84a0c2c11556a5424446a4) | `` editorconfig-checker: 3.2.1 -> 3.3.0 ``                                             |
| [`2003eb30`](https://github.com/NixOS/nixpkgs/commit/2003eb30e4ce960b9146b370445dd5bd4e53b873) | `` home-assistant: 2025.5.0 -> 2025.5.1 ``                                             |
| [`ca250b2e`](https://github.com/NixOS/nixpkgs/commit/ca250b2e9d44ee4f9fd4f04423d36a0c42b0c33d) | `` slang: disable pcre module ``                                                       |
| [`2d61a6f2`](https://github.com/NixOS/nixpkgs/commit/2d61a6f2a6df2c95550d27a203374f98362f2b6a) | `` pythonPackages.sigstore-protobuf-specs: do not auto-update this ``                  |