### PR TITLE
feat: Update better-control to latest 'main' commit 10a58fa

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -19,14 +19,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "better-control";
-  version = "2ec64b577a15751a5abb3cd231cea0d0d7096b20";
+  version = "10a58fa7f62a60c35b106d902029e3707b57121f";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "quantumvoid0";
     repo = "better-control";
     rev = "${version}";
-    hash = "sha256-Hd34sJ8uZo21hZWaabrijuFm7FgWWptw0ygx4prVt0w=";
+    hash = "sha256-58IOeRx6AbAAxUesuL1NhA2G8Gg3751NiBa7UpW3E4Y=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
This PR automatically updates the `better-control` package from commit `2ec64b5` to `10a58fa`.

Full commit SHAs:
- Old: `2ec64b577a15751a5abb3cd231cea0d0d7096b20`
- New: `10a58fa7f62a60c35b106d902029e3707b57121f`

This update fetches the latest commit from the `main` branch of the `quantumvoid0/better-control` repository.

Changes generated by GitHub Actions workflow.